### PR TITLE
Stream oldfile read and newfile write to reduce bspatch memory usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # go-bsdiff
 Pure Go implementation of [bsdiff](http://www.daemonology.net/bsdiff/) 4.
 
-[![GoDoc](https://godoc.org/github.com/gabstv/go-bsdiff?status.svg)](https://godoc.org/github.com/gabstv/go-bsdiff)
-[![Go Report Card](https://goreportcard.com/badge/github.com/gabstv/go-bsdiff)](https://goreportcard.com/report/github.com/gabstv/go-bsdiff)
-[![Build Status](https://travis-ci.org/gabstv/go-bsdiff.svg?branch=master)](https://travis-ci.org/gabstv/go-bsdiff)
-[![Coverage Status](https://coveralls.io/repos/github/gabstv/go-bsdiff/badge.svg?branch=master)](https://coveralls.io/github/gabstv/go-bsdiff?branch=master)
-<!--[![codecov](https://codecov.io/gh/gabstv/go-bsdiff/branch/master/graph/badge.svg)](https://codecov.io/gh/gabstv/go-bsdiff)-->
+[![GoDoc](https://godoc.org/github.com/kiteco/go-bsdiff?status.svg)](https://godoc.org/github.com/kiteco/go-bsdiff)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kiteco/go-bsdiff)](https://goreportcard.com/report/github.com/kiteco/go-bsdiff)
+[![Build Status](https://travis-ci.org/kiteco/go-bsdiff.svg?branch=master)](https://travis-ci.org/kiteco/go-bsdiff)
+[![Coverage Status](https://coveralls.io/repos/github/kiteco/go-bsdiff/badge.svg?branch=master)](https://coveralls.io/github/kiteco/go-bsdiff?branch=master)
+<!--[![codecov](https://codecov.io/gh/kiteco/go-bsdiff/branch/master/graph/badge.svg)](https://codecov.io/gh/kiteco/go-bsdiff)-->
 
 bsdiff and bspatch are tools for building and applying patches to binary files. By using suffix sorting (specifically, Larsson and Sadakane's [qsufsort](http://www.larsson.dogma.net/ssrev-tr.pdf)) and taking advantage of how executable files change.
 
@@ -21,8 +21,8 @@ import (
   "fmt"
   "bytes"
 
-  "github.com/gabstv/go-bsdiff/pkg/bsdiff"
-  "github.com/gabstv/go-bsdiff/pkg/bspatch"
+  "github.com/kiteco/go-bsdiff/pkg/bsdiff"
+  "github.com/kiteco/go-bsdiff/pkg/bspatch"
 )
 
 func main(){
@@ -55,8 +55,8 @@ import (
   "fmt"
   "bytes"
 
-  "github.com/gabstv/go-bsdiff/pkg/bsdiff"
-  "github.com/gabstv/go-bsdiff/pkg/bspatch"
+  "github.com/kiteco/go-bsdiff/pkg/bsdiff"
+  "github.com/kiteco/go-bsdiff/pkg/bspatch"
 )
 
 func main(){
@@ -82,7 +82,7 @@ func main(){
 
 ## As a program (CLI)
 ```sh
-go get -u -v github.com/gabstv/go-bsdiff/cmd/...
+go get -u -v github.com/kiteco/go-bsdiff/cmd/...
 
 bsdiff oldfile newfile patch
 bspatch oldfile newfile2 patch

--- a/cmd/bsdiff/main.go
+++ b/cmd/bsdiff/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/gabstv/go-bsdiff/pkg/bsdiff"
+	"github.com/kiteco/go-bsdiff/pkg/bsdiff"
 )
 
 func main() {

--- a/cmd/bspatch/main.go
+++ b/cmd/bspatch/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/gabstv/go-bsdiff/pkg/bspatch"
+	"github.com/kiteco/go-bsdiff/pkg/bspatch"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
-module github.com/gabstv/go-bsdiff
+module github.com/kiteco/go-bsdiff
+
+go 1.14
 
 require github.com/dsnet/compress v0.0.0-20171208185109-cc9eb1d7ad76

--- a/n_test.go
+++ b/n_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/gabstv/go-bsdiff/pkg/bsdiff"
-	"github.com/gabstv/go-bsdiff/pkg/bspatch"
+	"github.com/kiteco/go-bsdiff/pkg/bsdiff"
+	"github.com/kiteco/go-bsdiff/pkg/bspatch"
 )
 
 func TestDiffPatch(t *testing.T) {

--- a/pkg/bsdiff/bsdiff.go
+++ b/pkg/bsdiff/bsdiff.go
@@ -32,7 +32,7 @@ import (
 	"io/ioutil"
 
 	"github.com/dsnet/compress/bzip2"
-	"github.com/gabstv/go-bsdiff/pkg/util"
+	"github.com/kiteco/go-bsdiff/pkg/util"
 )
 
 // Bytes takes the old and new byte slices and outputs the diff

--- a/pkg/bsdiff/bsdiff_test.go
+++ b/pkg/bsdiff/bsdiff_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gabstv/go-bsdiff/pkg/util"
+	"github.com/kiteco/go-bsdiff/pkg/util"
 )
 
 func TestDiff(t *testing.T) {

--- a/pkg/bspatch/bspatch.go
+++ b/pkg/bspatch/bspatch.go
@@ -34,7 +34,7 @@ import (
 	"os"
 
 	"github.com/dsnet/compress/bzip2"
-	"github.com/gabstv/go-bsdiff/pkg/util"
+	"github.com/kiteco/go-bsdiff/pkg/util"
 )
 
 // Variables for streaming

--- a/pkg/bspatch/bspatch_test.go
+++ b/pkg/bspatch/bspatch_test.go
@@ -45,8 +45,8 @@ func TestPatch(t *testing.T) {
 	}
 
 	tests := []struct {
-		wbufsz int
-		rbufsz int
+		wbufsz  int
+		cpbufsz int
 	}{
 		{50, 50},
 		{19, 19},
@@ -62,10 +62,10 @@ func TestPatch(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		WriteBufferSize = test.wbufsz
-		ReadBufferSize = test.rbufsz
+		writeBufferSize = test.wbufsz
+		copyBufferSize = test.cpbufsz
 
-		desc := fmt.Sprintf("WriteBufferSize: %v, ReadBufferSize: %v", WriteBufferSize, ReadBufferSize)
+		desc := fmt.Sprintf("writeBufferSize: %v, copyBufferSize: %v", writeBufferSize, copyBufferSize)
 		newfile, err := Bytes(oldfile, patchfile)
 		if err != nil {
 			t.Errorf("With %s failed with error: %s", desc, err.Error())
@@ -296,28 +296,4 @@ func (r *lowcaprdr) Read(b []byte) (int, error) {
 	copy(r.read[r.n:], b)
 	r.n += len(b)
 	return len(b), nil
-}
-
-func TestZReadAll(t *testing.T) {
-	buf := []byte{
-		0x10, 0x10, 0x10, 0x10, 0x20, 0x20, 0x20, 0x20,
-		0x30, 0x30, 0x30, 0x30, 0x40, 0x40, 0x40, 0x40,
-		0x43,
-	}
-	rr := &lowcaprdr{
-		read: make([]byte, 1024),
-	}
-	nr, err := zreadall(rr, buf, int64(len(buf)))
-	if err != nil {
-		t.Fail()
-	}
-	if nr != int64(len(buf)) {
-		t.Fail()
-	}
-	if buf[16] != rr.read[16] {
-		t.Fail()
-	}
-	if buf[7] != rr.read[7] {
-		t.Fail()
-	}
 }

--- a/pkg/bspatch/bspatch_test.go
+++ b/pkg/bspatch/bspatch_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gabstv/go-bsdiff/pkg/util"
+	"github.com/kiteco/go-bsdiff/pkg/util"
 )
 
 func TestPatch(t *testing.T) {

--- a/pkg/bspatch/byte_add_reader.go
+++ b/pkg/bspatch/byte_add_reader.go
@@ -1,0 +1,59 @@
+package bspatch
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+var ErrUnequalReads = errors.New("byteAdder.Read: did not read equal number of bytes from both readers")
+
+type byteAddReader struct {
+	r1   io.Reader
+	r2   io.Reader
+	addb []byte
+}
+
+func newByteAddReader(r1 io.Reader, r2 io.Reader) byteAddReader {
+	return byteAddReader{
+		r1:   r1,
+		r2:   r2,
+		addb: make([]byte, ReadBufferSize),
+	}
+}
+
+// Read adds the bytes of the two readers and writes to using p as scratch space.
+func (ba byteAddReader) Read(p []byte) (written int, err error) {
+	chunk := min(len(p), ReadBufferSize)
+
+	for written < len(p) {
+		r1n, r1err := ba.r1.Read(ba.addb[:min(chunk, len(p)-written)])
+		r2n, r2err := ba.r2.Read(p[written:min(written+chunk, len(p))])
+		n := min(r1n, r2n)
+
+		for i := 0; i < n; i++ {
+			p[written+i] += ba.addb[i]
+		}
+		written += n
+
+		switch {
+		case r1n != r2n:
+			err = ErrUnequalReads
+			return
+		case r1err == nil && r2err == nil:
+			continue
+		case isNilorEOF(r1err) && isNilorEOF(r2err):
+			err = io.EOF
+			return
+		case !isNilorEOF(r1err) || !isNilorEOF(r2err):
+			err = fmt.Errorf("%s, %s", r1err, r2err)
+			return
+		}
+	}
+
+	return
+}
+
+func isNilorEOF(err error) bool {
+	return err == io.EOF || err == nil
+}

--- a/pkg/bspatch/corrupt_patch_error.go
+++ b/pkg/bspatch/corrupt_patch_error.go
@@ -1,0 +1,24 @@
+package bspatch
+
+import "fmt"
+
+type CorruptPatchError struct {
+	Name string
+}
+
+func newCorruptPatchError(e string) CorruptPatchError {
+	return CorruptPatchError{"corrupt patch: " + e}
+}
+
+// Functionally, consumers should handle a corrupt patch and a bz end error the same.
+func newCorruptPatchBzEndError(read int64, expected int64, label string, prevErr error) CorruptPatchError {
+	errmsg := fmt.Sprintf("corrupt patch or bz stream ended: %s read (%v/%v) ", label, read, expected)
+	if prevErr != nil {
+		errmsg += prevErr.Error()
+	}
+	return CorruptPatchError{errmsg}
+}
+
+func (e CorruptPatchError) Error() string {
+	return e.Name
+}

--- a/pkg/bspatch/write_counter.go
+++ b/pkg/bspatch/write_counter.go
@@ -1,0 +1,22 @@
+package bspatch
+
+import "io"
+
+type writeCounter struct {
+	w io.Writer
+	n int64
+}
+
+func newWriteCounter(w io.Writer) *writeCounter {
+	return &writeCounter{w, 0}
+}
+
+func (wc *writeCounter) Write(p []byte) (int, error) {
+	n, err := wc.w.Write(p)
+	wc.n += int64(n)
+	return n, err
+}
+
+func (wc writeCounter) Count() int64 {
+	return wc.n
+}


### PR DESCRIPTION
### What was done

Refactored bspatch to stream reads from the old file and writes to the new file to avoid holding both in memory, added an error type to reduce amount of error handling code for readability, refactored existing tests to accommodate the changes and to test a variety of write buffer sizes.

### Considerations

The buffer values will need to be tuned for performance. I decided not to used a buffered reader for the old file since seeking could go backward, it wasn't clear to me the size of each read from the old file, and would add some additional complexity. Can add if reading from disk looks to be a large bottleneck.